### PR TITLE
0.14.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.1
+
+This version adds the `formatPropertyValue` method to: `PropertyContext`, `DefaultValueContext`, `ScopedPropertyContext` and `ValueContext` classes.
+
 ## 0.14.0
 
 From now, the nullable any variable editor and the nullable variable editor display the expected variable types to select. This version also allows changes to the labels in the dropdown menu of the dynamic value editor.

--- a/demos/webpack-app/package.json
+++ b/demos/webpack-app/package.json
@@ -18,8 +18,8 @@
 		"sequential-workflow-model": "^0.2.0",
 		"sequential-workflow-designer": "^0.21.2",
 		"sequential-workflow-machine": "^0.4.0",
-		"sequential-workflow-editor-model": "^0.14.0",
-		"sequential-workflow-editor": "^0.14.0"
+		"sequential-workflow-editor-model": "^0.14.1",
+		"sequential-workflow-editor": "^0.14.1"
 	},
 	"devDependencies": {
 		"ts-loader": "^9.4.2",

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sequential-workflow-editor",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"type": "module",
 	"main": "./lib/esm/index.js",
 	"types": "./lib/index.d.ts",
@@ -46,11 +46,11 @@
 		"prettier:fix": "prettier --write ./src ./css"
 	},
 	"dependencies": {
-		"sequential-workflow-editor-model": "^0.14.0",
+		"sequential-workflow-editor-model": "^0.14.1",
 		"sequential-workflow-model": "^0.2.0"
 	},
 	"peerDependencies": {
-		"sequential-workflow-editor-model": "^0.14.0",
+		"sequential-workflow-editor-model": "^0.14.1",
 		"sequential-workflow-model": "^0.2.0"
 	},
 	"devDependencies": {

--- a/model/package.json
+++ b/model/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sequential-workflow-editor-model",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"homepage": "https://nocode-js.com/",
 	"author": {
 		"name": "NoCode JS",

--- a/model/src/context/default-value-context.ts
+++ b/model/src/context/default-value-context.ts
@@ -16,5 +16,6 @@ export class DefaultValueContext<TProperties extends Properties = Properties> {
 	) {}
 
 	public readonly getPropertyValue = this.propertyContext.getPropertyValue;
+	public readonly formatPropertyValue = this.propertyContext.formatPropertyValue;
 	public readonly activateStep = this.activator.activateStep;
 }

--- a/model/src/context/property-context.ts
+++ b/model/src/context/property-context.ts
@@ -18,11 +18,37 @@ export class PropertyContext<TProperties extends Properties = Properties> {
 		private readonly definitionModel: DefinitionModel
 	) {}
 
+	/**
+	 * Get the value of a property by name.
+	 * @param name The name of the property.
+	 * @returns The value of the property.
+	 */
 	public readonly getPropertyValue = <Key extends keyof TProperties>(name: Key): TProperties[Key] => {
 		return readPropertyValue(name, this.propertyModel, this.object);
 	};
 
+	/**
+	 * @returns The supported value types for variables.
+	 */
 	public readonly getValueTypes = (): ValueType[] => {
 		return this.definitionModel.valueTypes;
+	};
+
+	/**
+	 * Format a property value using a formatter function.
+	 * @param name The name of the property.
+	 * @param formatter The formatter function.
+	 * @param undefinedValue The value to return if the property value is `null` or `undefined`.
+	 */
+	public readonly formatPropertyValue = <Key extends keyof TProperties>(
+		name: Key,
+		formatter: (value: NonNullable<TProperties[Key]>) => string,
+		undefinedValue?: string
+	): string => {
+		const value = this.getPropertyValue(name);
+		if (value === undefined || value === null) {
+			return undefinedValue || '?';
+		}
+		return formatter(value);
 	};
 }

--- a/model/src/context/scoped-property-context.ts
+++ b/model/src/context/scoped-property-context.ts
@@ -21,6 +21,7 @@ export class ScopedPropertyContext<TProperties extends Properties> {
 	) {}
 
 	public readonly getPropertyValue = this.propertyContext.getPropertyValue;
+	public readonly formatPropertyValue = this.propertyContext.formatPropertyValue;
 	public readonly getValueTypes = this.propertyContext.getValueTypes;
 
 	public readonly hasVariable = (variableName: string, valueType: string | null): boolean => {

--- a/model/src/context/value-context.ts
+++ b/model/src/context/value-context.ts
@@ -26,6 +26,7 @@ export class ValueContext<TValueModel extends ValueModel = ValueModel, TProperti
 	) {}
 
 	public readonly getPropertyValue = this.scopedPropertyContext.getPropertyValue;
+	public readonly formatPropertyValue = this.scopedPropertyContext.formatPropertyValue;
 	public readonly getValueTypes = this.scopedPropertyContext.getValueTypes;
 	public readonly hasVariable = this.scopedPropertyContext.hasVariable;
 	public readonly findFirstUndefinedVariable = this.scopedPropertyContext.findFirstUndefinedVariable;

--- a/model/src/value-models/generated-string/generated-string-context.ts
+++ b/model/src/value-models/generated-string/generated-string-context.ts
@@ -17,15 +17,5 @@ export class GeneratedStringContext<TProperties extends Properties = Properties>
 	) {}
 
 	public readonly getPropertyValue = this.context.getPropertyValue;
-
-	public formatPropertyValue<Key extends keyof TProperties>(
-		name: Key,
-		formatter: (value: NonNullable<TProperties[Key]>) => string
-	): string {
-		const value = this.getPropertyValue(name);
-		if (value === undefined || value === null) {
-			return '?';
-		}
-		return formatter(value);
-	}
+	public readonly formatPropertyValue = this.context.formatPropertyValue;
 }


### PR DESCRIPTION
This version adds the `formatPropertyValue` method to: `PropertyContext`, `DefaultValueContext`, `ScopedPropertyContext` and `ValueContext` classes.
